### PR TITLE
Change to use update tokens

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,12 +12,16 @@ gnome = import('gnome')
 
 config_h = configuration_data()
 config_h.set_quoted('FRONTEND_URL', get_option('frontend_url'))
+config_h.set_quoted('BACKEND_URL', get_option('api_url'))
+config_h.set_quoted('PROGRAM_NAME', meson.project_name())
+config_h.set_quoted('PROGRAM_VERSION', meson.project_version())
 configure_file(
   output: 'flathub_authenticator-config.h',
   configuration: config_h,
 )
 add_project_arguments([
   '-I' + meson.build_root(),
+  '-DG_LOG_DOMAIN="@0@"'.format(meson.project_name()),
 ], language: 'c')
 
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,7 @@
 option('frontend_url',
        type: 'string', value: 'http://localhost:3000',
        description: 'URL of the flathub website')
+
+option('api_url',
+       type: 'string', value: 'http://localhost:8000',
+       description: 'URL of the flathub store API')

--- a/org.flathub.Authenticator.json
+++ b/org.flathub.Authenticator.json
@@ -21,6 +21,25 @@
     ],
     "modules" : [
         {
+            "name" : "libsecret",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dmanpage=false",
+                "-Dvapi=false",
+                "-Dgtk_doc=false",
+                "-Dintrospection=false",
+                "-Dbash_completion=disabled"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libsecret.git",
+                    "tag" : "0.20.5",
+                    "commit" : "d64530ac70d9723945d68ca079293ea0f9df9e9f"
+                }
+            ]
+        },
+        {
             "name" : "flathub-authenticator",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ flathub_authenticator_deps = [
   dependency('gio-unix-2.0'),
   dependency('libsoup-2.4'),
   dependency('json-glib-1.0'),
+  dependency('libsecret-1'),
 ]
 
 gnome = import('gnome')

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ flathub_authenticator_deps = [
   dependency('gio-2.0'),
   dependency('gio-unix-2.0'),
   dependency('libsoup-2.4'),
+  dependency('json-glib-1.0'),
 ]
 
 gnome = import('gnome')


### PR DESCRIPTION
Instead of asking the frontend for a download token, we now ask it for an update token and use that to get a download token ourselves from the backend. In the future, the update token will be stored so that app updates can be done without invoking the webflow.